### PR TITLE
chore: init Phase 1 workflow (status + decisions)

### DIFF
--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -1,0 +1,50 @@
+# Decisions log
+
+Human-authored guidance for agents. Read at session start by every
+feat-agent (per `dev/agent-feature-workflow.md`) and the orchestrator
+(per `.agents/agents/lead-orchestrator.md` Step 1).
+
+Most-recent decisions on top.
+
+---
+
+## 2026-04-30 — Phase 1 implementation kickoff
+
+- **Authoritative spec**: `PHASE_1_SPEC.md` is the contract. Any
+  ambiguity not covered there is an open question, not an
+  implementer's call. Open questions get filed as a comment on the
+  Phase 1 milestone.
+- **Language**: Python 3.11+. `pandas` permitted but not required —
+  the reconciler's math is small enough to run on stdlib if a contributor
+  prefers. Tests via `pytest`.
+- **Test discipline**: TDD per fixture. For each of the 13 fixtures in
+  PHASE_1_SPEC.md §10, write the expected JSON output BEFORE the code
+  that makes it pass. Fixture #6 is load-bearing — it must fail under
+  any row-walk implementation and pass only under event-walk.
+- **PR chain over parallel tracks**: Phase 1 is small + sequential, so
+  one track (`phase-1-reconciler`) with a chain of stacked PRs, not
+  parallel feat-* tracks. Revisit for Phase 2.
+- **Walk semantics is non-negotiable**: event-walk. Reviewers reject
+  any PR that introduces row-walk logic, even as an "optimization."
+  See PHASE_1_SPEC.md §1.1 + §5.
+
+## 2026-04-30 — Agent harness adoption
+
+- Bootstrapped via `agent-harness init`. See PR #2.
+- Filed `dayfine/agent-harness#14` for three first-run polish issues
+  (missing `.gitignore`, blind `CLAUDE.md` overwrite, stale stub
+  comment in `bin/agent-harness`).
+- `qc-structural-authority.md` and `qc-behavioral-authority.md` not
+  yet written. Defer until first feat-agent dispatch needs them.
+- `dev/lib/run-in-env.sh` ships generic; Python adaptation deferred to
+  the first feat-agent that runs `pytest`.
+
+## 2026-04-29 — Project bootstrap
+
+- This repo exists because `trading-1`'s internal QC shares the same
+  OCaml accounting code that generates the trades. External
+  reconciler in a separate language closes the same-bug-passes-same-test
+  hole. See `README.md` §"Why this lives in a separate repo".
+- Phase boundaries fixed in README §Roadmap. Don't expand Phase 1
+  scope — the value is in shipping the first version fast and
+  validating the contract.

--- a/dev/plans/README.md
+++ b/dev/plans/README.md
@@ -1,0 +1,11 @@
+# Engineering plans
+
+Per-track engineering plans live here as `<track>-<YYYY-MM-DD>.md`.
+The orchestrator's Step 3.5 produces these when a track needs an
+upfront design pass before code; subsequent feat-agent dispatches
+read the approved plan as binding §Approach + §Out-of-scope context.
+
+No plans yet — Phase 1's design lives directly in `PHASE_1_SPEC.md`,
+which serves as the binding plan for the `phase-1-reconciler` track.
+Add per-PR plans here only if a slice grows large enough to need its
+own design pass.

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -1,0 +1,34 @@
+# Status Index
+
+Single-source view of all tracked work. Update when a status file flips
+state, an owner changes, or a PR opens / merges / closes. Keep the table
+terse; detail belongs in the per-track status files linked in column 1.
+
+Last updated: 2026-04-30 — initial Phase 1 track defined.
+
+## Active + complete tracks
+
+| Track | Status | Owner | Open PR(s) | Next task |
+|---|---|---|---|---|
+| [phase-1-reconciler](phase-1-reconciler.md) | NOT_STARTED | unassigned | — | Implement parser + types (PR-A) |
+
+## How to use
+
+- **Find what's in flight**: filter rows by Status = IN_PROGRESS.
+- **Find what needs an owner**: look for empty Owner cells on non-MERGED rows.
+- **Find what's awaiting review**: check the Open PR column.
+- **Find the next concrete task** for a track: read its "Next task" cell.
+- **Start a session**: open the linked status file to get full context.
+
+## Maintenance
+
+Agent-owned update: any agent that touches `dev/status/<track>.md`
+during a session must also update that track's row here if Status,
+Owner, Open PR, or Next task changed. Agents only touch their own row,
+so parallel write conflicts stay rare.
+
+Orchestrator reconciliation: `lead-orchestrator` diffs this index
+against the per-track status files at end-of-run and flags drift.
+
+Adding a new track means creating the status file AND adding a row
+here in the same commit.

--- a/dev/status/phase-1-reconciler.md
+++ b/dev/status/phase-1-reconciler.md
@@ -1,0 +1,134 @@
+# Track: phase-1-reconciler
+
+**Status**: NOT_STARTED
+**Owner**: unassigned
+**Milestone**: [Phase 1 — bootstrap](https://github.com/dayfine/trading-reconciler/milestone/1)
+**Spec**: [`PHASE_1_SPEC.md`](../../PHASE_1_SPEC.md) (authoritative)
+
+Single sequential track for the entire Phase 1 reconciler. Three
+stacked PRs (A → B → C), each landing a coherent slice of the spec
+with its corresponding fixtures green.
+
+---
+
+## PR chain
+
+### PR-A — parser + event-walk core (closed-trade only)
+
+Tracking issue: [#3](https://github.com/dayfine/trading-reconciler/issues/3)
+
+**Scope**: foundation that makes simple round-trips reconcile.
+
+- Parser for `--trades` (both 13-col and 12-col headers per §2.2).
+- Validation rules per §2.4.
+- Event constructor + sort key per §5 (no splits, no open-positions yet).
+- Walker: cash + open-position state, per-leg cash deltas per §1.4.
+- Per-row P&L recompute per §1.2; tolerance compare per §6.1.
+- Cash-floor check per §1.1 + §6.3.
+- JSON output emitter (sexp deferred to PR-C).
+- Exit-code mapping per §9.
+
+**Fixtures green**: #1 `simple_long`, #2 `simple_short`, #3
+`mixed_long_short`, #6 `cash_floor_violation_event_walk`, #7
+`pnl_disagrees`, #11 `legacy_12col`, #12 `intra_day_round_trip`.
+
+**Critical**: fixture #6 is the load-bearing test for event-walk
+semantics. PR-A does not land without it green.
+
+**Out of scope**: splits, open-positions, commissions, sexp output,
+`--strict-fp`, `--verbose`.
+
+**Estimated size**: 600–900 lines (impl + tests).
+
+---
+
+### PR-B — splits + open-positions + unrealized
+
+Tracking issue: [#4](https://github.com/dayfine/trading-reconciler/issues/4)
+
+**Scope**: held-through-split + end-of-run reporting.
+
+- `--splits` parser + Split events per §4.
+- Split application during walk per §4.2; boundary convention §4.3.
+- `--open-positions` parser + entry-event injection per §3.2.
+- `--final-prices` parser; unrealized P&L per §3.3.
+- End-of-run aggregation: `realized_pnl_total`, `unrealized_pnl_total`,
+  `total_value`, `total_return_pct` per §1.5.
+- Exit code 5 (missing open-position price).
+
+**Fixtures green** (in addition to PR-A's): #4
+`held_through_4to1_split`, #5 `held_through_4to1_split_no_splits_input`,
+#10 `open_position_missing_price`, #13 `open_positions_with_split`.
+
+**Out of scope**: commissions, sexp output, `--strict-fp`,
+`--verbose`.
+
+**Estimated size**: 400–600 lines.
+
+---
+
+### PR-C — commissions + tolerance polish + sexp emitter
+
+Tracking issue: [#5](https://github.com/dayfine/trading-reconciler/issues/5)
+
+**Scope**: spec completion.
+
+- `--commission-per-share` + `--commission-per-trade` flags wired into
+  P&L formulas (§1.2) and per-leg cash deltas (§1.4).
+- `--strict-fp` mode + co-passed-flag warnings per §6.2.
+- `--epsilon-relative` / `--epsilon-absolute` flag plumbing (likely
+  already wired in PR-A; verify).
+- Sexp emitter; encoding documented in implementation README.
+- `--verbose` flag → stderr INFO traces.
+- `--slippage-bps` flag accepted but ignored (reserved for Phase 2).
+
+**Fixtures green** (in addition to PR-A + PR-B): #8 `commission_match`,
+#9 `commission_mismatch`.
+
+**Out of scope**: anything in §11 (Phase 2+).
+
+**Estimated size**: 300–500 lines.
+
+---
+
+## Branch + base layout
+
+PRs stack on each other; each based on the prior PR's branch:
+
+```
+main
+ └── feat/phase-1-reconciler/parser-and-event-walk    (PR-A)
+      └── feat/phase-1-reconciler/splits-and-opens    (PR-B, base = PR-A)
+           └── feat/phase-1-reconciler/commissions-and-sexp  (PR-C, base = PR-B)
+```
+
+Per `dev/agent-feature-workflow.md`: never branch from a feature
+branch directly; PR-B opens only after PR-A merges to main, etc.
+This serializes the chain but keeps each PR reviewable in isolation.
+
+If parallel work becomes desirable later (e.g. PR-B and PR-C both
+depend on PR-A but not on each other), split into multiple tracks.
+
+---
+
+## Definition of done
+
+- All 13 fixtures from `PHASE_1_SPEC.md` §10 green via `pytest`.
+- `bin/agent-harness-check.sh` passes.
+- `README.md` updated with reconciler installation + invocation
+  example.
+- Implementation README documents sexp encoding choice (per §12.1)
+  and any deviation from the spec.
+- All `<TODO: ...>` placeholders in `.agents/agents/lead-orchestrator.md`
+  + `.github/workflows/orchestrator.yml` resolved (orchestrator can
+  actually run; or, alternatively, the orchestrator workflow is
+  disabled until Phase 2 — decide before PR-A merges).
+
+---
+
+## Next task
+
+Implement parser + types for `--trades` CSV (13-col + 12-col headers
+per §2.2). Validation per §2.4. Tests for fixtures #1, #11 minimal
+(parse + validate; no walk yet). Open as PR-A draft; full PR-A
+completion includes the event-walk core.


### PR DESCRIPTION
## Summary

- Defines the Phase 1 implementation workflow per the agent-harness conventions: track files, decisions log, status index.
- Single sequential track (`phase-1-reconciler`) with three stacked PRs (PR-A → PR-B → PR-C). Phase 1 is small enough to not need parallel feat-tracks; revisit for Phase 2.
- GitHub milestone [Phase 1 — bootstrap](https://github.com/dayfine/trading-reconciler/milestone/1) with tracking issues #3 (PR-A), #4 (PR-B), #5 (PR-C).

## Files

- `dev/decisions.md` — human-authored guidance log; read by feat-agents at session start.
- `dev/status/_index.md` — track index.
- `dev/status/phase-1-reconciler.md` — the track. Defines scope, fixtures, and DoD per PR.
- `dev/plans/README.md` — placeholder; PHASE_1_SPEC.md is the binding plan.

## Test plan

- [x] `bin/agent-harness-check.sh` passes (status files have no tags by design — they're not in the harness layer model).
- [ ] Harness Check workflow passes on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)