### PR TITLE
feat(phase-1): splits + open-positions + unrealized (PR-B)

### DIFF
--- a/src/reconciler/cli.py
+++ b/src/reconciler/cli.py
@@ -10,7 +10,13 @@ from .models import (
     SEVERITY_MISSING_PRICE,
     SEVERITY_PNL_MISMATCH,
 )
-from .parser import ParseError, parse_trades
+from .parser import (
+    ParseError,
+    parse_final_prices,
+    parse_open_positions,
+    parse_splits,
+    parse_trades,
+)
 from .tolerance import Tolerance
 from .walker import walk
 
@@ -33,6 +39,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="reconciler")
     p.add_argument("--trades", required=True, type=Path)
     p.add_argument("--initial-cash", required=True, type=float)
+    p.add_argument("--open-positions", type=Path)
+    p.add_argument("--final-prices", type=Path)
+    p.add_argument("--splits", type=Path)
     p.add_argument("--commission-per-share", type=float, default=0.0)
     p.add_argument("--commission-per-trade", type=float, default=0.0)
     p.add_argument("--epsilon-relative", type=float, default=1e-6)
@@ -67,6 +76,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         trades = parse_trades(args.trades)
+        opens = parse_open_positions(args.open_positions) if args.open_positions else []
+        splits = parse_splits(args.splits) if args.splits else []
+        final_prices = parse_final_prices(args.final_prices) if args.final_prices else None
     except ParseError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return EXIT_PARSE
@@ -75,6 +87,9 @@ def main(argv: list[str] | None = None) -> int:
         trades,
         args.initial_cash,
         tolerance=tolerance,
+        open_positions=opens,
+        splits=splits,
+        final_prices=final_prices,
         commission_per_share=args.commission_per_share,
         commission_per_trade=args.commission_per_trade,
     )

--- a/src/reconciler/emit.py
+++ b/src/reconciler/emit.py
@@ -22,19 +22,18 @@ def _trade_to_dict(t: TradeResult) -> dict[str, Any]:
 
 
 def _open_to_dict(o: OpenPositionResult) -> dict[str, Any]:
-    d: dict[str, Any] = {
+    return {
         "symbol": o.symbol,
         "side": o.side.value,
         "entry_date": o.entry_date.isoformat(),
         "cost_basis_per_share": o.cost_basis_per_share,
         "effective_quantity": o.effective_quantity,
+        "final_price": o.final_price,
+        "unrealized_pnl": o.unrealized_pnl,
     }
-    d["final_price"] = o.final_price
-    d["unrealized_pnl"] = o.unrealized_pnl
-    return d
 
 
-def _summary(result: WalkResult, unrealized_total: float | None) -> dict[str, Any]:
+def _summary(result: WalkResult) -> dict[str, Any]:
     realized = sum(t.computed_pnl for t in result.trade_results)
     long_count = sum(1 for t in result.trade_results if t.side == Side.LONG)
     short_count = sum(1 for t in result.trade_results if t.side == Side.SHORT)
@@ -43,6 +42,7 @@ def _summary(result: WalkResult, unrealized_total: float | None) -> dict[str, An
     trade_count = len(result.trade_results)
     win_rate_pct = (win_count / trade_count * 100.0) if trade_count else 0.0
 
+    unrealized_total = result.unrealized_pnl_total
     if unrealized_total is None:
         total_value: float | None = None
         total_return_pct: float | None = None
@@ -74,9 +74,9 @@ def _summary(result: WalkResult, unrealized_total: float | None) -> dict[str, An
     }
 
 
-def to_json(result: WalkResult, *, unrealized_total: float | None = None) -> str:
+def to_json(result: WalkResult) -> str:
     payload = {
-        "summary": _summary(result, unrealized_total),
+        "summary": _summary(result),
         "trades": [_trade_to_dict(t) for t in result.trade_results],
         "open_positions": [_open_to_dict(o) for o in result.open_positions],
         "divergences": [

--- a/src/reconciler/events.py
+++ b/src/reconciler/events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .models import Event, EventKind, Trade
+from .models import Event, EventKind, OpenPosition, Split, Trade
 
 
 def events_from_trades(trades: list[Trade]) -> list[Event]:
@@ -29,6 +29,37 @@ def events_from_trades(trades: list[Trade]) -> list[Event]:
             )
         )
     return events
+
+
+def events_from_open_positions(opens: list[OpenPosition]) -> list[Event]:
+    return [
+        Event(
+            date=o.entry_date,
+            kind=EventKind.ENTRY,
+            symbol=o.symbol,
+            side=o.side,
+            price=o.entry_price,
+            quantity=o.quantity,
+            source_row=o.row,
+            is_open_position=True,
+        )
+        for o in opens
+    ]
+
+
+def events_from_splits(splits: list[Split]) -> list[Event]:
+    return [
+        Event(
+            date=s.date,
+            kind=EventKind.SPLIT,
+            symbol=s.symbol,
+            side=None,
+            price=s.factor,
+            quantity=0.0,
+            source_row=s.row,
+        )
+        for s in splits
+    ]
 
 
 def sort_events(events: list[Event]) -> list[Event]:

--- a/src/reconciler/models.py
+++ b/src/reconciler/models.py
@@ -11,6 +11,24 @@ class Side(StrEnum):
 
 
 @dataclass(frozen=True)
+class OpenPosition:
+    row: int
+    symbol: str
+    side: Side
+    entry_date: date
+    entry_price: float
+    quantity: float
+
+
+@dataclass(frozen=True)
+class Split:
+    row: int
+    symbol: str
+    date: date
+    factor: float
+
+
+@dataclass(frozen=True)
 class Trade:
     row: int
     symbol: str

--- a/src/reconciler/parser.py
+++ b/src/reconciler/parser.py
@@ -4,7 +4,11 @@ import csv
 from datetime import date, datetime
 from pathlib import Path
 
-from .models import Side, Trade
+from .models import OpenPosition, Side, Split, Trade
+
+HEADER_OPEN_POSITIONS = "symbol,side,entry_date,entry_price,quantity"
+HEADER_SPLITS = "symbol,date,factor"
+HEADER_FINAL_PRICES = "symbol,price"
 
 HEADER_13_COL = (
     "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,"
@@ -117,3 +121,105 @@ def parse_trades(path: str | Path) -> list[Trade]:
             )
 
         return trades
+
+
+def parse_open_positions(path: str | Path) -> list[OpenPosition]:
+    p = Path(path)
+    with p.open() as f:
+        reader = csv.reader(f)
+        try:
+            header_row = next(reader)
+        except StopIteration as e:
+            raise ParseError(f"{p}: empty file") from e
+
+        if ",".join(header_row) != HEADER_OPEN_POSITIONS:
+            raise ParseError(
+                f"{p}: header must be {HEADER_OPEN_POSITIONS!r}; got: {','.join(header_row)!r}"
+            )
+
+        rows: list[OpenPosition] = []
+        for i, raw in enumerate(reader, start=1):
+            if len(raw) != 5:
+                raise ParseError(f"open-positions row {i}: expected 5 columns, got {len(raw)}")
+            symbol, side_s, entry_d, entry_p, qty = raw
+            side = _parse_side(side_s, row=i)
+            entry_date = _parse_date(entry_d, field="entry_date", row=i)
+            entry_price = _parse_float(entry_p, field="entry_price", row=i)
+            quantity = _parse_float(qty, field="quantity", row=i)
+            if entry_price <= 0:
+                raise ParseError(
+                    f"open-positions row {i}: entry_price must be > 0, got {entry_price}"
+                )
+            if quantity <= 0:
+                raise ParseError(f"open-positions row {i}: quantity must be > 0, got {quantity}")
+            rows.append(
+                OpenPosition(
+                    row=i,
+                    symbol=symbol,
+                    side=side,
+                    entry_date=entry_date,
+                    entry_price=entry_price,
+                    quantity=quantity,
+                )
+            )
+        return rows
+
+
+def parse_splits(path: str | Path) -> list[Split]:
+    p = Path(path)
+    with p.open() as f:
+        reader = csv.reader(f)
+        try:
+            header_row = next(reader)
+        except StopIteration as e:
+            raise ParseError(f"{p}: empty file") from e
+
+        if ",".join(header_row) != HEADER_SPLITS:
+            raise ParseError(
+                f"{p}: header must be {HEADER_SPLITS!r}; got: {','.join(header_row)!r}"
+            )
+
+        rows: list[Split] = []
+        seen: set[tuple[str, str]] = set()
+        for i, raw in enumerate(reader, start=1):
+            if len(raw) != 3:
+                raise ParseError(f"splits row {i}: expected 3 columns, got {len(raw)}")
+            symbol, date_s, factor_s = raw
+            split_date = _parse_date(date_s, field="date", row=i)
+            factor = _parse_float(factor_s, field="factor", row=i)
+            if factor <= 0:
+                raise ParseError(f"splits row {i}: factor must be > 0, got {factor}")
+            key = (symbol, date_s)
+            if key in seen:
+                raise ParseError(f"splits row {i}: duplicate ({symbol}, {date_s})")
+            seen.add(key)
+            rows.append(Split(row=i, symbol=symbol, date=split_date, factor=factor))
+        return rows
+
+
+def parse_final_prices(path: str | Path) -> dict[str, float]:
+    p = Path(path)
+    with p.open() as f:
+        reader = csv.reader(f)
+        try:
+            header_row = next(reader)
+        except StopIteration as e:
+            raise ParseError(f"{p}: empty file") from e
+
+        if ",".join(header_row) != HEADER_FINAL_PRICES:
+            raise ParseError(
+                f"{p}: header must be {HEADER_FINAL_PRICES!r}; got: {','.join(header_row)!r}"
+            )
+
+        prices: dict[str, float] = {}
+        for i, raw in enumerate(reader, start=1):
+            if len(raw) != 2:
+                raise ParseError(f"final-prices row {i}: expected 2 columns, got {len(raw)}")
+            symbol, price_s = raw
+            price = _parse_float(price_s, field="price", row=i)
+            if price <= 0:
+                raise ParseError(f"final-prices row {i}: price must be > 0, got {price}")
+            if symbol in prices:
+                raise ParseError(f"final-prices row {i}: duplicate symbol {symbol}")
+            prices[symbol] = price
+        return prices

--- a/src/reconciler/pnl.py
+++ b/src/reconciler/pnl.py
@@ -13,11 +13,30 @@ def compute_pnl(
     commission_per_share: float = 0.0,
     commission_per_trade: float = 0.0,
 ) -> float:
-    leg = commissions_per_leg(trade.quantity, commission_per_share, commission_per_trade)
-    if trade.side == Side.LONG:
-        gross = (trade.exit_price - trade.entry_price) * trade.quantity
+    return compute_pnl_lot(
+        cost_basis_per_share=trade.entry_price,
+        exit_price=trade.exit_price,
+        quantity=trade.quantity,
+        side=trade.side,
+        commission_per_share=commission_per_share,
+        commission_per_trade=commission_per_trade,
+    )
+
+
+def compute_pnl_lot(
+    *,
+    cost_basis_per_share: float,
+    exit_price: float,
+    quantity: float,
+    side: Side,
+    commission_per_share: float = 0.0,
+    commission_per_trade: float = 0.0,
+) -> float:
+    leg = commissions_per_leg(quantity, commission_per_share, commission_per_trade)
+    if side == Side.LONG:
+        gross = (exit_price - cost_basis_per_share) * quantity
     else:
-        gross = (trade.entry_price - trade.exit_price) * trade.quantity
+        gross = (cost_basis_per_share - exit_price) * quantity
     return gross - 2.0 * leg
 
 

--- a/src/reconciler/walker.py
+++ b/src/reconciler/walker.py
@@ -4,18 +4,25 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import date
 
-from .events import events_from_trades, sort_events
+from .events import (
+    events_from_open_positions,
+    events_from_splits,
+    events_from_trades,
+    sort_events,
+)
 from .models import (
     SEVERITY_CASH_FLOOR,
+    SEVERITY_MISSING_PRICE,
     SEVERITY_PNL_MISMATCH,
     Divergence,
-    Event,
     EventKind,
     Lot,
+    OpenPosition,
     Side,
+    Split,
     Trade,
 )
-from .pnl import compute_pnl, compute_pnl_percent, entry_cash_delta, exit_cash_delta
+from .pnl import compute_pnl_lot, compute_pnl_percent, entry_cash_delta, exit_cash_delta
 from .tolerance import Tolerance
 
 
@@ -50,6 +57,7 @@ class WalkResult:
     trade_results: list[TradeResult] = field(default_factory=list)
     open_positions: list[OpenPositionResult] = field(default_factory=list)
     divergences: list[Divergence] = field(default_factory=list)
+    unrealized_pnl_total: float | None = None
 
 
 def walk(
@@ -57,10 +65,20 @@ def walk(
     initial_cash: float,
     *,
     tolerance: Tolerance,
+    open_positions: list[OpenPosition] | None = None,
+    splits: list[Split] | None = None,
+    final_prices: dict[str, float] | None = None,
     commission_per_share: float = 0.0,
     commission_per_trade: float = 0.0,
 ) -> WalkResult:
-    events = sort_events(events_from_trades(trades))
+    open_positions = open_positions or []
+    splits = splits or []
+
+    events = sort_events(
+        events_from_trades(trades)
+        + events_from_open_positions(open_positions)
+        + events_from_splits(splits)
+    )
     open_lots: dict[str, list[Lot]] = defaultdict(list)
     cash = initial_cash
     result = WalkResult(initial_cash=initial_cash, final_cash=cash)
@@ -68,47 +86,54 @@ def walk(
     trade_by_row: dict[int, Trade] = {t.row: t for t in trades}
 
     for ev in events:
-        cash = _apply(ev, cash, open_lots, commission_per_share, commission_per_trade)
-
-        if ev.kind == EventKind.EXIT and not ev.is_open_position:
-            t = trade_by_row[ev.source_row]
-            computed = compute_pnl(
-                t,
+        if ev.kind == EventKind.ENTRY:
+            assert ev.side is not None
+            cash += entry_cash_delta(
+                ev.side,
+                ev.price,
+                ev.quantity,
                 commission_per_share=commission_per_share,
                 commission_per_trade=commission_per_trade,
             )
-            diff = computed - t.pnl_dollars
-            verdict = "MATCH" if tolerance.matches(t.pnl_dollars, computed) else "MISMATCH"
-            result.trade_results.append(
-                TradeResult(
-                    row=t.row,
-                    symbol=t.symbol,
-                    side=t.side,
-                    entry_date=t.entry_date,
-                    exit_date=t.exit_date,
-                    computed_pnl=computed,
-                    input_pnl=t.pnl_dollars,
-                    divergence=diff,
-                    verdict=verdict,
+            open_lots[ev.symbol].append(
+                Lot(
+                    symbol=ev.symbol,
+                    side=ev.side,
+                    cost_basis_per_share=ev.price,
+                    quantity=ev.quantity,
+                    entry_date=ev.date,
                 )
             )
-            if verdict == "MISMATCH":
-                computed_pct = compute_pnl_percent(t, computed)
-                result.divergences.append(
-                    Divergence(
-                        type="pnl_mismatch",
-                        severity=SEVERITY_PNL_MISMATCH,
-                        payload={
-                            "row": t.row,
-                            "symbol": t.symbol,
-                            "input_pnl": t.pnl_dollars,
-                            "computed_pnl": computed,
-                            "diff": diff,
-                            "input_pnl_percent": t.pnl_percent,
-                            "computed_pnl_percent": computed_pct,
-                        },
-                    )
+
+        elif ev.kind == EventKind.EXIT:
+            lots = open_lots.get(ev.symbol)
+            if not lots:
+                continue
+            lot = lots.pop(0)
+            if not lots:
+                del open_lots[ev.symbol]
+            assert ev.side is not None
+            cash += exit_cash_delta(
+                ev.side,
+                ev.price,
+                lot.quantity,
+                commission_per_share=commission_per_share,
+                commission_per_trade=commission_per_trade,
+            )
+            if not ev.is_open_position:
+                t = trade_by_row[ev.source_row]
+                computed = compute_pnl_lot(
+                    cost_basis_per_share=lot.cost_basis_per_share,
+                    exit_price=ev.price,
+                    quantity=lot.quantity,
+                    side=t.side,
+                    commission_per_share=commission_per_share,
+                    commission_per_trade=commission_per_trade,
                 )
+                _record_trade_result(result, t, computed, tolerance)
+
+        elif ev.kind == EventKind.SPLIT:
+            _apply_split(open_lots, ev.symbol, ev.price)
 
         if tolerance.cash_floor_violated(cash):
             result.divergences.append(
@@ -124,55 +149,102 @@ def walk(
             )
 
     result.final_cash = cash
-    for symbol, lots in open_lots.items():
-        for lot in lots:
-            result.open_positions.append(
-                OpenPositionResult(
-                    symbol=symbol,
-                    side=lot.side,
-                    entry_date=lot.entry_date,
-                    cost_basis_per_share=lot.cost_basis_per_share,
-                    effective_quantity=lot.quantity,
-                )
-            )
-    result.open_positions.sort(key=lambda p: (p.symbol, p.entry_date))
+    _populate_open_positions(result, open_lots, final_prices)
     return result
 
 
-def _apply(
-    ev: Event,
-    cash: float,
-    open_lots: dict[str, list[Lot]],
-    commission_per_share: float,
-    commission_per_trade: float,
-) -> float:
-    if ev.kind == EventKind.ENTRY:
-        cash += entry_cash_delta(
-            ev.side,
-            ev.price,
-            ev.quantity,
-            commission_per_share=commission_per_share,
-            commission_per_trade=commission_per_trade,
+def _apply_split(
+    open_lots: dict[str, list[Lot]], symbol: str, factor: float
+) -> None:
+    if symbol not in open_lots:
+        return
+    open_lots[symbol] = [
+        Lot(
+            symbol=lot.symbol,
+            side=lot.side,
+            cost_basis_per_share=lot.cost_basis_per_share / factor,
+            quantity=lot.quantity * factor,
+            entry_date=lot.entry_date,
         )
-        open_lots[ev.symbol].append(
-            Lot(
-                symbol=ev.symbol,
-                side=ev.side,
-                cost_basis_per_share=ev.price,
-                quantity=ev.quantity,
-                entry_date=ev.date,
+        for lot in open_lots[symbol]
+    ]
+
+
+def _record_trade_result(
+    result: WalkResult, t: Trade, computed: float, tolerance: Tolerance
+) -> None:
+    diff = computed - t.pnl_dollars
+    verdict = "MATCH" if tolerance.matches(t.pnl_dollars, computed) else "MISMATCH"
+    result.trade_results.append(
+        TradeResult(
+            row=t.row,
+            symbol=t.symbol,
+            side=t.side,
+            entry_date=t.entry_date,
+            exit_date=t.exit_date,
+            computed_pnl=computed,
+            input_pnl=t.pnl_dollars,
+            divergence=diff,
+            verdict=verdict,
+        )
+    )
+    if verdict == "MISMATCH":
+        result.divergences.append(
+            Divergence(
+                type="pnl_mismatch",
+                severity=SEVERITY_PNL_MISMATCH,
+                payload={
+                    "row": t.row,
+                    "symbol": t.symbol,
+                    "input_pnl": t.pnl_dollars,
+                    "computed_pnl": computed,
+                    "diff": diff,
+                    "input_pnl_percent": t.pnl_percent,
+                    "computed_pnl_percent": compute_pnl_percent(t, computed),
+                },
             )
         )
-    elif ev.kind == EventKind.EXIT:
-        cash += exit_cash_delta(
-            ev.side,
-            ev.price,
-            ev.quantity,
-            commission_per_share=commission_per_share,
-            commission_per_trade=commission_per_trade,
-        )
-        if open_lots[ev.symbol]:
-            open_lots[ev.symbol].pop(0)
-            if not open_lots[ev.symbol]:
-                del open_lots[ev.symbol]
-    return cash
+
+
+def _populate_open_positions(
+    result: WalkResult,
+    open_lots: dict[str, list[Lot]],
+    final_prices: dict[str, float] | None,
+) -> None:
+    unrealized_total = 0.0
+    has_unrealized = final_prices is not None
+    missing_symbols: list[str] = []
+    for symbol, lots in open_lots.items():
+        for lot in lots:
+            r = OpenPositionResult(
+                symbol=symbol,
+                side=lot.side,
+                entry_date=lot.entry_date,
+                cost_basis_per_share=lot.cost_basis_per_share,
+                effective_quantity=lot.quantity,
+            )
+            if has_unrealized:
+                final_price = final_prices.get(symbol)
+                if final_price is None:
+                    missing_symbols.append(symbol)
+                else:
+                    r.final_price = final_price
+                    if lot.side == Side.LONG:
+                        r.unrealized_pnl = (final_price - lot.cost_basis_per_share) * lot.quantity
+                    else:
+                        r.unrealized_pnl = (lot.cost_basis_per_share - final_price) * lot.quantity
+                    unrealized_total += r.unrealized_pnl
+            result.open_positions.append(r)
+    result.open_positions.sort(key=lambda p: (p.symbol, p.entry_date))
+    if has_unrealized and not missing_symbols:
+        result.unrealized_pnl_total = unrealized_total
+    if missing_symbols:
+        for sym in sorted(set(missing_symbols)):
+            result.divergences.append(
+                Divergence(
+                    type="missing_open_position_price",
+                    severity=SEVERITY_MISSING_PRICE,
+                    payload={"symbol": sym},
+                )
+            )
+        result.unrealized_pnl_total = None

--- a/tests/fixtures/held_through_4to1_split.csv
+++ b/tests/fixtures/held_through_4to1_split.csv
@@ -1,0 +1,2 @@
+symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger
+AAPL,LONG,2020-08-15,2020-09-15,31,480.00,130.00,100,4000.00,8.3333,460.00,130.00,target

--- a/tests/fixtures/held_through_4to1_split.splits.csv
+++ b/tests/fixtures/held_through_4to1_split.splits.csv
@@ -1,0 +1,2 @@
+symbol,date,factor
+AAPL,2020-08-31,4.0

--- a/tests/fixtures/open_position_missing_price.opens.csv
+++ b/tests/fixtures/open_position_missing_price.opens.csv
@@ -1,0 +1,2 @@
+symbol,side,entry_date,entry_price,quantity
+MSFT,LONG,2024-01-05,300.00,50

--- a/tests/fixtures/open_position_missing_price.prices.csv
+++ b/tests/fixtures/open_position_missing_price.prices.csv
@@ -1,0 +1,2 @@
+symbol,price
+AAPL,160.00

--- a/tests/fixtures/open_position_missing_price.trades.csv
+++ b/tests/fixtures/open_position_missing_price.trades.csv
@@ -1,0 +1,2 @@
+symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger
+AAPL,LONG,2024-01-02,2024-02-15,44,150.00,160.00,100,1000.00,6.6667,140.00,160.00,target

--- a/tests/fixtures/open_positions_with_split.opens.csv
+++ b/tests/fixtures/open_positions_with_split.opens.csv
@@ -1,0 +1,2 @@
+symbol,side,entry_date,entry_price,quantity
+AAPL,LONG,2020-08-15,480.00,100

--- a/tests/fixtures/open_positions_with_split.prices.csv
+++ b/tests/fixtures/open_positions_with_split.prices.csv
@@ -1,0 +1,2 @@
+symbol,price
+AAPL,130.00

--- a/tests/fixtures/open_positions_with_split.splits.csv
+++ b/tests/fixtures/open_positions_with_split.splits.csv
@@ -1,0 +1,2 @@
+symbol,date,factor
+AAPL,2020-08-31,4.0

--- a/tests/fixtures/open_positions_with_split.trades.csv
+++ b/tests/fixtures/open_positions_with_split.trades.csv
@@ -1,0 +1,1 @@
+symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,56 @@ def test_exit_2_parse_error(tmp_path):
     assert code == EXIT_PARSE
 
 
+def test_exit_0_held_through_split_with_splits():
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "held_through_4to1_split.csv"),
+            "--initial-cash",
+            "50000",
+            "--splits",
+            str(FIXTURES / "held_through_4to1_split.splits.csv"),
+        ]
+    )
+    assert code == EXIT_OK
+
+
+def test_exit_5_open_position_missing_price():
+    from reconciler.cli import EXIT_MISSING_PRICE
+
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "open_position_missing_price.trades.csv"),
+            "--initial-cash",
+            "1000000",
+            "--open-positions",
+            str(FIXTURES / "open_position_missing_price.opens.csv"),
+            "--final-prices",
+            str(FIXTURES / "open_position_missing_price.prices.csv"),
+        ]
+    )
+    assert code == EXIT_MISSING_PRICE
+
+
+def test_exit_0_open_position_with_split():
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "open_positions_with_split.trades.csv"),
+            "--initial-cash",
+            "50000",
+            "--open-positions",
+            str(FIXTURES / "open_positions_with_split.opens.csv"),
+            "--splits",
+            str(FIXTURES / "open_positions_with_split.splits.csv"),
+            "--final-prices",
+            str(FIXTURES / "open_positions_with_split.prices.csv"),
+        ]
+    )
+    assert code == EXIT_OK
+
+
 def test_strict_fp_warns_on_explicit_epsilon(capsys):
     main(
         [

--- a/tests/test_parser_splits.py
+++ b/tests/test_parser_splits.py
@@ -1,0 +1,67 @@
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from reconciler.models import Side
+from reconciler.parser import (
+    ParseError,
+    parse_final_prices,
+    parse_open_positions,
+    parse_splits,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parses_open_positions():
+    opens = parse_open_positions(FIXTURES / "open_position_missing_price.opens.csv")
+    assert len(opens) == 1
+    o = opens[0]
+    assert o.symbol == "MSFT"
+    assert o.side == Side.LONG
+    assert o.entry_date == date(2024, 1, 5)
+    assert o.entry_price == 300.0
+    assert o.quantity == 50.0
+
+
+def test_parses_splits():
+    splits = parse_splits(FIXTURES / "held_through_4to1_split.splits.csv")
+    assert len(splits) == 1
+    s = splits[0]
+    assert s.symbol == "AAPL"
+    assert s.date == date(2020, 8, 31)
+    assert s.factor == 4.0
+
+
+def test_parses_final_prices():
+    prices = parse_final_prices(FIXTURES / "open_position_missing_price.prices.csv")
+    assert prices == {"AAPL": 160.0}
+
+
+def test_open_positions_rejects_bad_header(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_text("symbol,xxx\n")
+    with pytest.raises(ParseError, match="header must be"):
+        parse_open_positions(p)
+
+
+def test_splits_rejects_zero_factor(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_text("symbol,date,factor\nAAPL,2024-01-01,0\n")
+    with pytest.raises(ParseError, match="factor must be > 0"):
+        parse_splits(p)
+
+
+def test_splits_rejects_duplicate(tmp_path):
+    p = tmp_path / "dup.csv"
+    p.write_text("symbol,date,factor\nAAPL,2024-01-01,2\nAAPL,2024-01-01,3\n")
+    with pytest.raises(ParseError, match="duplicate"):
+        parse_splits(p)
+
+
+def test_final_prices_rejects_duplicate(tmp_path):
+    p = tmp_path / "dup.csv"
+    p.write_text("symbol,price\nAAPL,160\nAAPL,170\n")
+    with pytest.raises(ParseError, match="duplicate symbol"):
+        parse_final_prices(p)

--- a/tests/test_phase_1_open_questions.py
+++ b/tests/test_phase_1_open_questions.py
@@ -1,0 +1,36 @@
+"""Tests pinned to spec ambiguities that PR-B surfaced.
+
+Each xfail here links to a milestone issue. When the spec lands a
+resolution, flip the test from xfail to a hard assertion."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reconciler.cli import main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Spec ambiguity: PHASE_1_SPEC.md §2.5/§4.3/§10 fixture #5 say exit 2 "
+        "for held-through-split row without --splits, but the in-window "
+        "predicate requires known splits. Current behavior: exit 3 "
+        "(pnl_mismatch). See dayfine/trading-reconciler#9."
+    ),
+    strict=True,
+)
+def test_held_through_split_without_splits_exits_2():
+    from reconciler.cli import EXIT_PARSE
+
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "held_through_4to1_split.csv"),
+            "--initial-cash",
+            "50000",
+        ]
+    )
+    assert code == EXIT_PARSE

--- a/tests/test_walker_splits.py
+++ b/tests/test_walker_splits.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+from reconciler.parser import (
+    parse_final_prices,
+    parse_open_positions,
+    parse_splits,
+    parse_trades,
+)
+from reconciler.tolerance import Tolerance
+from reconciler.walker import walk
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_held_through_4to1_split_with_splits_input():
+    trades = parse_trades(FIXTURES / "held_through_4to1_split.csv")
+    splits = parse_splits(FIXTURES / "held_through_4to1_split.splits.csv")
+    r = walk(trades, 50_000.0, tolerance=Tolerance.default(), splits=splits)
+    assert len(r.trade_results) == 1
+    tr = r.trade_results[0]
+    assert tr.verdict == "MATCH"
+    assert tr.computed_pnl == 4000.0
+    assert r.divergences == []
+    assert r.final_cash == 54_000.0
+
+
+def test_open_position_with_split_propagates_to_unrealized():
+    trades = parse_trades(FIXTURES / "open_positions_with_split.trades.csv")
+    opens = parse_open_positions(FIXTURES / "open_positions_with_split.opens.csv")
+    splits = parse_splits(FIXTURES / "open_positions_with_split.splits.csv")
+    prices = parse_final_prices(FIXTURES / "open_positions_with_split.prices.csv")
+    r = walk(
+        trades,
+        50_000.0,
+        tolerance=Tolerance.default(),
+        open_positions=opens,
+        splits=splits,
+        final_prices=prices,
+    )
+    assert len(r.open_positions) == 1
+    op = r.open_positions[0]
+    assert op.symbol == "AAPL"
+    assert op.cost_basis_per_share == 120.0
+    assert op.effective_quantity == 400.0
+    assert op.final_price == 130.0
+    assert op.unrealized_pnl == 4000.0
+    assert r.unrealized_pnl_total == 4000.0
+    assert r.divergences == []
+
+
+def test_open_position_missing_final_price_emits_exit5_divergence():
+    trades = parse_trades(FIXTURES / "open_position_missing_price.trades.csv")
+    opens = parse_open_positions(FIXTURES / "open_position_missing_price.opens.csv")
+    prices = parse_final_prices(FIXTURES / "open_position_missing_price.prices.csv")
+    r = walk(
+        trades,
+        1_000_000.0,
+        tolerance=Tolerance.default(),
+        open_positions=opens,
+        final_prices=prices,
+    )
+    missing = [d for d in r.divergences if d.type == "missing_open_position_price"]
+    assert len(missing) == 1
+    assert missing[0].payload["symbol"] == "MSFT"
+    assert r.unrealized_pnl_total is None
+
+
+def test_short_position_with_split_adjusts_correctly():
+    """A short held through a 2:1 split. cost_basis halves, qty doubles."""
+    from reconciler.models import OpenPosition, Side, Split
+    from datetime import date
+
+    opens = [
+        OpenPosition(
+            row=1,
+            symbol="X",
+            side=Side.SHORT,
+            entry_date=date(2024, 1, 1),
+            entry_price=100.0,
+            quantity=10,
+        )
+    ]
+    splits = [Split(row=1, symbol="X", date=date(2024, 2, 1), factor=2.0)]
+    prices = {"X": 40.0}
+    r = walk(
+        trades=[],
+        initial_cash=10_000.0,
+        tolerance=Tolerance.default(),
+        open_positions=opens,
+        splits=splits,
+        final_prices=prices,
+    )
+    assert len(r.open_positions) == 1
+    op = r.open_positions[0]
+    assert op.cost_basis_per_share == 50.0
+    assert op.effective_quantity == 20.0
+    # SHORT unrealized = (cost_basis - final) * qty = (50 - 40) * 20 = 200
+    assert op.unrealized_pnl == 200.0

--- a/tests/test_walker_splits.py
+++ b/tests/test_walker_splits.py
@@ -1,5 +1,7 @@
+from datetime import date
 from pathlib import Path
 
+from reconciler.models import OpenPosition, Side, Split
 from reconciler.parser import (
     parse_final_prices,
     parse_open_positions,
@@ -67,9 +69,6 @@ def test_open_position_missing_final_price_emits_exit5_divergence():
 
 def test_short_position_with_split_adjusts_correctly():
     """A short held through a 2:1 split. cost_basis halves, qty doubles."""
-    from reconciler.models import OpenPosition, Side, Split
-    from datetime import date
-
     opens = [
         OpenPosition(
             row=1,


### PR DESCRIPTION
Second PR in the Phase 1 chain. Closes #4 modulo merge. Spec ambiguity filed as #9.

## Summary

Implements `PHASE_1_SPEC.md` §3 (open positions), §4 (splits), §1.5 (end-of-run aggregation), §3.3 (unrealized P&L). Lands the AAPL canonical-example fixture green.

## Modules touched

| Module | Change |
|---|---|
| `models.py` | + `OpenPosition`, `Split` dataclasses |
| `parser.py` | + `parse_open_positions`, `parse_splits`, `parse_final_prices` with header-literal validation |
| `events.py` | + `events_from_open_positions` (Entry-only per §3.2), `events_from_splits` (layer-0 sort) |
| `pnl.py` | + `compute_pnl_lot`; existing `compute_pnl` thin-wraps it |
| `walker.py` | Split events adjust lot cost_basis ÷ factor, qty × factor (§4.2). Exit cash delta uses lot's possibly-adjusted qty at raw post-split price. Missing final-price → severity 5 divergence. |
| `emit.py` | `open_positions[]` now carries `effective_quantity`, `cost_basis_per_share`, `final_price`, `unrealized_pnl`. Summary `total_value` + `total_return_pct` populate when unrealized known. |
| `cli.py` | Wires `--open-positions`, `--final-prices`, `--splits` flags. |

## Fixtures landed

| # | Fixture | Expected |
|---|---|---|
| 4 | `held_through_4to1_split.csv` + matching splits | exit 0 — AAPL canonical example, P&L = +$4000 |
| 10 | `open_position_missing_price.*` | exit 5 — MSFT held but absent from `--final-prices` |
| 13 | `open_positions_with_split.*` | exit 0 — AAPL open through 4:1 split, unrealized = $4000 |

Plus a unit test for SHORT positions through splits (cost basis halves, qty doubles).

## Deferred

Fixture #5 (`held_through_4to1_split_no_splits_input`) is marked `xfail` in `tests/test_phase_1_open_questions.py`. The spec's claimed exit 2 conflicts with the in-window predicate; current behavior produces exit 3 via natural P&L divergence detection. **See #9 for resolution proposals**; per `dev/decisions.md` the feat-agent files an issue rather than inventing the spec.

## Test plan

- [ ] Test workflow passes on Python 3.11 + 3.12 (8 new tests pass; xfail records pending issue).
- [ ] Harness Check workflow passes.
- [ ] All PR-A fixtures still green (no regression on lot-based P&L for non-split rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)