### PR TITLE
feat(phase-1): commissions wired + sexp emitter + verbose (PR-C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,36 @@ in `trading-1` (the reconciler's math is verifiable by hand).
 
 **2026-04-29** — Repo bootstrapped with this design doc.
 
-**2026-04-30** — `PHASE_1_SPEC.md` finalized. Definitive contract for
-the Phase 1 reconciler: event-walk semantics, strict realized-cash
-floor, 13 hand-computed test fixtures, severity-based exit codes.
-Implementation pending.
+**2026-04-30** — `PHASE_1_SPEC.md` finalized. Phase 1 implemented in
+PRs A/B/C. 12/13 fixtures green; #5 xfail pending spec clarification
+in [#9](https://github.com/dayfine/trading-reconciler/issues/9).
 
 Read order for implementers: this `README.md` (design rationale +
 phases) → `PHASE_1_SPEC.md` (authoritative I/O contract + accounting).
+
+## Quick start
+
+```bash
+pip install -e '.[dev]'
+pytest -v
+
+# Run against a trades file:
+reconciler --trades trades.csv --initial-cash 1000000
+
+# With splits + open positions + final prices:
+reconciler \
+  --trades trades.csv \
+  --initial-cash 1000000 \
+  --splits splits.csv \
+  --open-positions opens.csv \
+  --final-prices final.csv \
+  --format json
+
+# Sexp output for OCaml-side consumption:
+reconciler --trades trades.csv --initial-cash 1000000 --format sexp
+```
+
+Exit code is the load-bearing CI signal — see `PHASE_1_SPEC.md` §9.
 
 ## Cross-references in `trading-1`
 

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,13 +4,13 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-30 — initial Phase 1 track defined.
+Last updated: 2026-04-30 — Phase 1 closure (PR-C in flight).
 
 ## Active + complete tracks
 
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
-| [phase-1-reconciler](phase-1-reconciler.md) | NOT_STARTED | unassigned | — | Implement parser + types (PR-A) |
+| [phase-1-reconciler](phase-1-reconciler.md) | COMPLETE | unassigned | PR-C | Phase 2 starts new track |
 
 ## How to use
 

--- a/dev/status/phase-1-reconciler.md
+++ b/dev/status/phase-1-reconciler.md
@@ -1,6 +1,6 @@
 # Track: phase-1-reconciler
 
-**Status**: NOT_STARTED
+**Status**: COMPLETE (modulo merge of PR-C)
 **Owner**: unassigned
 **Milestone**: [Phase 1 — bootstrap](https://github.com/dayfine/trading-reconciler/milestone/1)
 **Spec**: [`PHASE_1_SPEC.md`](../../PHASE_1_SPEC.md) (authoritative)
@@ -128,7 +128,31 @@ depend on PR-A but not on each other), split into multiple tracks.
 
 ## Next task
 
-Implement parser + types for `--trades` CSV (13-col + 12-col headers
-per §2.2). Validation per §2.4. Tests for fixtures #1, #11 minimal
-(parse + validate; no walk yet). Open as PR-A draft; full PR-A
-completion includes the event-walk core.
+Phase 1 complete after PR-C merges. Phase 2 work (soft-floor with
+mid-trajectory MtM via `--daily-prices`, splits/ops research,
+trading-1 integration) starts in a new track — see
+`PHASE_1_SPEC.md` §11 for deferred items and `README.md` §Roadmap
+Phase 2+ for sequencing.
+
+Open question still pending: spec ambiguity #9 (held-through-split
+without `--splits` exit code). Resolution flips
+`tests/test_phase_1_open_questions.py` from xfail to a hard
+assertion.
+
+## Fixtures landed (13/13)
+
+| # | Fixture | PR | Status |
+|---|---|---|---|
+| 1 | `simple_long.csv` | PR-A | green |
+| 2 | `simple_short.csv` | PR-A | green |
+| 3 | `mixed_long_short.csv` | PR-A | green |
+| 4 | `held_through_4to1_split.csv` + matching splits | PR-B | green |
+| 5 | `held_through_4to1_split_no_splits_input` | PR-B | xfail (#9) |
+| 6 | `cash_floor_violation_event_walk.csv` | PR-A | green (load-bearing) |
+| 7 | `pnl_disagrees.csv` | PR-A | green |
+| 8 | `commission_match.csv` | PR-C | green |
+| 9 | `commission_mismatch.csv` | PR-C | green |
+| 10 | `open_position_missing_price.*` | PR-B | green |
+| 11 | `legacy_12col.csv` | PR-A | green |
+| 12 | `intra_day_round_trip.csv` | PR-A | green |
+| 13 | `open_positions_with_split.*` | PR-B | green |

--- a/src/reconciler/cli.py
+++ b/src/reconciler/cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from .emit import to_json
+from .emit import to_json, to_sexp
 from .models import (
     SEVERITY_CASH_FLOOR,
     SEVERITY_MISSING_PRICE,
@@ -44,10 +44,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--splits", type=Path)
     p.add_argument("--commission-per-share", type=float, default=0.0)
     p.add_argument("--commission-per-trade", type=float, default=0.0)
+    p.add_argument("--slippage-bps", type=float, default=0.0)
     p.add_argument("--epsilon-relative", type=float, default=1e-6)
     p.add_argument("--epsilon-absolute", type=float, default=0.01)
     p.add_argument("--strict-fp", action="store_true")
-    p.add_argument("--format", choices=["json"], default="json")
+    p.add_argument("--format", choices=["json", "sexp"], default="json")
     p.add_argument("--verbose", action="store_true")
     return p
 
@@ -74,6 +75,20 @@ def main(argv: list[str] | None = None) -> int:
     else:
         tolerance = Tolerance(rel=args.epsilon_relative, abs_=args.epsilon_absolute)
 
+    if args.slippage_bps != 0.0:
+        print(
+            f"WARN: --slippage-bps {args.slippage_bps} reserved for Phase 2; ignored.",
+            file=sys.stderr,
+        )
+
+    if args.verbose:
+        print(
+            f"INFO: tolerance rel={tolerance.rel} abs={tolerance.abs_} "
+            f"commission_per_share={args.commission_per_share} "
+            f"commission_per_trade={args.commission_per_trade}",
+            file=sys.stderr,
+        )
+
     try:
         trades = parse_trades(args.trades)
         opens = parse_open_positions(args.open_positions) if args.open_positions else []
@@ -93,7 +108,19 @@ def main(argv: list[str] | None = None) -> int:
         commission_per_share=args.commission_per_share,
         commission_per_trade=args.commission_per_trade,
     )
-    print(to_json(result))
+
+    if args.verbose:
+        print(
+            f"INFO: walked {len(trades)} trades, {len(opens)} open positions, "
+            f"{len(splits)} splits; final_cash={result.final_cash} "
+            f"divergences={len(result.divergences)}",
+            file=sys.stderr,
+        )
+
+    if args.format == "sexp":
+        print(to_sexp(result))
+    else:
+        print(to_json(result))
 
     if not result.divergences:
         return EXIT_OK

--- a/src/reconciler/emit.py
+++ b/src/reconciler/emit.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 from .models import Side
+from .sexp import encode as sexp_encode
 from .walker import OpenPositionResult, TradeResult, WalkResult
 
 
@@ -74,8 +75,8 @@ def _summary(result: WalkResult) -> dict[str, Any]:
     }
 
 
-def to_json(result: WalkResult) -> str:
-    payload = {
+def _payload(result: WalkResult) -> dict[str, Any]:
+    return {
         "summary": _summary(result),
         "trades": [_trade_to_dict(t) for t in result.trade_results],
         "open_positions": [_open_to_dict(o) for o in result.open_positions],
@@ -83,4 +84,11 @@ def to_json(result: WalkResult) -> str:
             {"type": d.type, **d.payload} for d in result.divergences
         ],
     }
-    return json.dumps(payload, indent=2, sort_keys=False)
+
+
+def to_json(result: WalkResult) -> str:
+    return json.dumps(_payload(result), indent=2, sort_keys=False)
+
+
+def to_sexp(result: WalkResult) -> str:
+    return sexp_encode(_payload(result))

--- a/src/reconciler/sexp.py
+++ b/src/reconciler/sexp.py
@@ -1,0 +1,43 @@
+"""Minimal s-expression serializer for OCaml-side consumption.
+
+Encoding choices (documented per PHASE_1_SPEC.md §12.1):
+- None       → `()`
+- True/False → `true` / `false`
+- str/date   → bare atom if no whitespace/parens, else double-quoted
+- int/float  → bare numeric atom (Python repr)
+- dict       → `((k1 v1) (k2 v2) ...)`
+- list       → `(v1 v2 ...)`
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_QUOTE_CHARS = set(" \t\n()\"")
+
+
+def _atom(s: str) -> str:
+    if not s:
+        return '""'
+    if any(c in _QUOTE_CHARS for c in s):
+        escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return s
+
+
+def encode(value: Any) -> str:
+    if value is None:
+        return "()"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, str):
+        return _atom(value)
+    if isinstance(value, dict):
+        parts = [f"({_atom(str(k))} {encode(v)})" for k, v in value.items()]
+        return "(" + " ".join(parts) + ")"
+    if isinstance(value, (list, tuple)):
+        parts = [encode(v) for v in value]
+        return "(" + " ".join(parts) + ")"
+    raise TypeError(f"sexp encode: unsupported type {type(value).__name__}")

--- a/tests/fixtures/commission_match.csv
+++ b/tests/fixtures/commission_match.csv
@@ -1,0 +1,2 @@
+symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger
+AAPL,LONG,2024-01-02,2024-02-15,44,100.00,105.00,100,498.00,4.9800,95.00,105.00,target

--- a/tests/fixtures/commission_mismatch.csv
+++ b/tests/fixtures/commission_mismatch.csv
@@ -1,0 +1,2 @@
+symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger
+AAPL,LONG,2024-01-02,2024-02-15,44,100.00,105.00,100,498.00,4.9800,95.00,105.00,target

--- a/tests/test_commissions_and_polish.py
+++ b/tests/test_commissions_and_polish.py
@@ -1,0 +1,167 @@
+"""Tests for PR-C: commissions wired through CLI, sexp output, --verbose, --slippage-bps."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reconciler.cli import EXIT_OK, EXIT_PNL_MISMATCH, main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_commission_match_with_correct_flag():
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "commission_match.csv"),
+            "--initial-cash",
+            "1000000",
+            "--commission-per-share",
+            "0.01",
+        ]
+    )
+    assert code == EXIT_OK
+
+
+def test_commission_mismatch_without_flag_diverges():
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "commission_mismatch.csv"),
+            "--initial-cash",
+            "1000000",
+        ]
+    )
+    assert code == EXIT_PNL_MISMATCH
+
+
+def test_commission_per_trade_flag():
+    """Per-trade commission applies to each leg → 2x per round-trip."""
+    # Simple LONG: 100 → 105, qty 100 → gross 500. With $5 per-trade × 2 legs = -$10.
+    # Net 490.
+    csv = FIXTURES.parent / "fixtures_tmp_commission_per_trade.csv"
+    csv.write_text(
+        "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,"
+        "pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger\n"
+        "AAPL,LONG,2024-01-02,2024-02-15,44,100,105,100,490,4.9,95,105,target\n"
+    )
+    try:
+        code = main(
+            [
+                "--trades",
+                str(csv),
+                "--initial-cash",
+                "1000000",
+                "--commission-per-trade",
+                "5.0",
+            ]
+        )
+        assert code == EXIT_OK
+    finally:
+        csv.unlink()
+
+
+def test_sexp_format_well_formed(capsys):
+    code = main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+            "--format",
+            "sexp",
+        ]
+    )
+    assert code == EXIT_OK
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("((summary")
+    # Balanced parens
+    assert out.count("(") == out.count(")")
+
+
+def test_sexp_format_does_not_quote_iso_dates(capsys):
+    main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+            "--format",
+            "sexp",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "2024-01-02" in out
+    assert '"2024-01-02"' not in out
+
+
+def test_json_format_remains_default(capsys):
+    main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+        ]
+    )
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert "summary" in parsed
+
+
+def test_slippage_bps_warns(capsys):
+    main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+            "--slippage-bps",
+            "5",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert "--slippage-bps" in err
+    assert "Phase 2" in err
+
+
+def test_slippage_bps_default_does_not_warn(capsys):
+    main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert "slippage" not in err.lower()
+
+
+def test_verbose_emits_info_to_stderr(capsys):
+    main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+            "--verbose",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert "INFO" in err
+    assert "tolerance" in err
+    assert "walked 3 trades" in err
+
+
+def test_quiet_default_emits_no_info(capsys):
+    main(
+        [
+            "--trades",
+            str(FIXTURES / "simple_long.csv"),
+            "--initial-cash",
+            "1000000",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert "INFO" not in err

--- a/tests/test_sexp.py
+++ b/tests/test_sexp.py
@@ -1,0 +1,50 @@
+from reconciler.sexp import encode
+
+
+def test_none_is_unit():
+    assert encode(None) == "()"
+
+
+def test_bool_atoms():
+    assert encode(True) == "true"
+    assert encode(False) == "false"
+
+
+def test_int_and_float():
+    assert encode(42) == "42"
+    assert encode(3.14) == "3.14"
+
+
+def test_atom_unquoted_when_safe():
+    assert encode("AAPL") == "AAPL"
+    assert encode("LONG") == "LONG"
+    assert encode("2024-01-02") == "2024-01-02"
+
+
+def test_atom_quoted_when_has_spaces():
+    assert encode("hello world") == '"hello world"'
+
+
+def test_empty_string_quoted():
+    assert encode("") == '""'
+
+
+def test_quote_escapes_quotes():
+    assert encode('a"b') == '"a\\"b"'
+
+
+def test_dict_emits_alist():
+    assert encode({"a": 1, "b": 2}) == "((a 1) (b 2))"
+
+
+def test_list_emits_paren_seq():
+    assert encode([1, 2, 3]) == "(1 2 3)"
+
+
+def test_nested_structure():
+    payload = {"summary": {"x": 1}, "items": [{"a": 1}, {"a": 2}]}
+    assert encode(payload) == "((summary ((x 1))) (items (((a 1)) ((a 2)))))"
+
+
+def test_null_field_in_dict():
+    assert encode({"unrealized": None}) == "((unrealized ()))"


### PR DESCRIPTION
Third and final PR in the Phase 1 chain. Closes #5 and the Phase 1 milestone modulo merge.

## Summary

Closes the Phase 1 contract: commissions wired through CLI to fixtures, sexp emitter for OCaml-side consumption, `--verbose` stderr traces, `--slippage-bps` accepted-but-ignored flag.

## New surfaces

| File | Change |
|---|---|
| `src/reconciler/sexp.py` | Minimal s-expression serializer per `PHASE_1_SPEC.md` §12.1. `None → ()`, `bool → true/false`, `dict → ((k v) ...)` alist, `list → (v1 v2 ...)`. |
| `src/reconciler/emit.py` | + `to_sexp()`; both formats share `_payload()` builder. |
| `src/reconciler/cli.py` | `--format sexp` wired; `--slippage-bps` accepted with stderr `WARN`; `--verbose` emits INFO traces. |

## Fixtures landed

| # | Fixture | Expected |
|---|---|---|
| 8 | `commission_match.csv` + `--commission-per-share 0.01` | exit 0 — net $498 reconciles |
| 9 | `commission_mismatch.csv` (no flag) | exit 3 — $2 diff > $0.01 abs threshold |

## Phase 1 closure

13 fixtures total: 12 green, #5 xfail pending [#9](https://github.com/dayfine/trading-reconciler/issues/9) spec resolution.

- `dev/status/phase-1-reconciler.md` → `COMPLETE`
- `dev/status/_index.md` mirrors
- `README.md` adds Quick start with CLI examples

## Test plan

- [ ] Test workflow passes on Python 3.11 + 3.12 (sexp + commissions + verbose tests added).
- [ ] Harness Check workflow passes.
- [ ] All earlier PR-A + PR-B fixtures still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)