### PR TITLE
feat(phase-1.5): cross-check reconciler totals vs simulator summary.sexp

### DIFF
--- a/src/reconciler/cli.py
+++ b/src/reconciler/cli.py
@@ -17,6 +17,11 @@ from .parser import (
     parse_splits,
     parse_trades,
 )
+from .summary_check import (
+    SummaryParseError,
+    cross_check,
+    parse_summary_sexp,
+)
 from .tolerance import Tolerance
 from .walker import walk
 
@@ -42,6 +47,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--open-positions", type=Path)
     p.add_argument("--final-prices", type=Path)
     p.add_argument("--splits", type=Path)
+    p.add_argument("--summary", type=Path)
     p.add_argument("--commission-per-share", type=float, default=0.0)
     p.add_argument("--commission-per-trade", type=float, default=0.0)
     p.add_argument("--slippage-bps", type=float, default=0.0)
@@ -108,6 +114,26 @@ def main(argv: list[str] | None = None) -> int:
         commission_per_share=args.commission_per_share,
         commission_per_trade=args.commission_per_trade,
     )
+
+    if args.summary is not None:
+        try:
+            sim_summary = parse_summary_sexp(args.summary)
+        except SummaryParseError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return EXIT_PARSE
+        realized_total = sum(t.computed_pnl for t in result.trade_results)
+        win_count = sum(1 for t in result.trade_results if t.computed_pnl > 0)
+        loss_count = sum(1 for t in result.trade_results if t.computed_pnl < 0)
+        result.divergences.extend(
+            cross_check(
+                sim_summary,
+                realized_pnl_total=realized_total,
+                win_count=win_count,
+                loss_count=loss_count,
+                trade_count=len(result.trade_results),
+                tolerance=tolerance,
+            )
+        )
 
     if args.verbose:
         print(

--- a/src/reconciler/sexp_reader.py
+++ b/src/reconciler/sexp_reader.py
@@ -1,0 +1,103 @@
+"""Minimal s-expression reader for parsing simulator summary.sexp.
+
+Handles atoms (bare or double-quoted with backslash escapes), parenthesized
+lists, line comments starting with `;`, and arbitrary whitespace. Returns
+nested Python lists of strings.
+"""
+
+from __future__ import annotations
+
+
+class SexpReadError(Exception):
+    pass
+
+
+def loads(text: str) -> list:
+    parser = _Parser(text)
+    parser._skip_ws()
+    if parser._eof():
+        raise SexpReadError("empty input")
+    value = parser._read_value()
+    parser._skip_ws()
+    if not parser._eof():
+        raise SexpReadError(f"trailing input at offset {parser.i}")
+    return value
+
+
+class _Parser:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.i = 0
+
+    def _eof(self) -> bool:
+        return self.i >= len(self.text)
+
+    def _peek(self) -> str:
+        return self.text[self.i] if not self._eof() else ""
+
+    def _skip_ws(self) -> None:
+        while not self._eof():
+            c = self.text[self.i]
+            if c.isspace():
+                self.i += 1
+            elif c == ";":
+                while not self._eof() and self.text[self.i] != "\n":
+                    self.i += 1
+            else:
+                return
+
+    def _read_value(self):
+        self._skip_ws()
+        if self._eof():
+            raise SexpReadError("unexpected EOF")
+        c = self._peek()
+        if c == "(":
+            return self._read_list()
+        if c == ")":
+            raise SexpReadError(f"unexpected ')' at offset {self.i}")
+        if c == '"':
+            return self._read_quoted()
+        return self._read_bare_atom()
+
+    def _read_list(self) -> list:
+        assert self._peek() == "("
+        self.i += 1
+        out: list = []
+        while True:
+            self._skip_ws()
+            if self._eof():
+                raise SexpReadError("unterminated list")
+            if self._peek() == ")":
+                self.i += 1
+                return out
+            out.append(self._read_value())
+
+    def _read_quoted(self) -> str:
+        assert self._peek() == '"'
+        self.i += 1
+        chars: list[str] = []
+        while True:
+            if self._eof():
+                raise SexpReadError("unterminated quoted atom")
+            c = self.text[self.i]
+            if c == '"':
+                self.i += 1
+                return "".join(chars)
+            if c == "\\":
+                self.i += 1
+                if self._eof():
+                    raise SexpReadError("dangling backslash")
+                chars.append(self.text[self.i])
+                self.i += 1
+                continue
+            chars.append(c)
+            self.i += 1
+
+    def _read_bare_atom(self) -> str:
+        start = self.i
+        while not self._eof():
+            c = self.text[self.i]
+            if c.isspace() or c in "()\";":
+                break
+            self.i += 1
+        return self.text[start:self.i]

--- a/src/reconciler/summary_check.py
+++ b/src/reconciler/summary_check.py
@@ -1,0 +1,201 @@
+"""Cross-check reconciler-computed totals against simulator's summary.sexp.
+
+Phase 1.5 — closes the gap that surfaced on goldens-broad/panel-golden-2019-full
+where reconciler `realized_pnl_total` disagreed with simulator's `totalpnl`
+metric (and `win_count`/`loss_count` disagreed with `wincount`/`losscount`)
+even though every per-row P&L matched.
+
+Format expected (from trading-1 backtest_runner output):
+
+    ((start_date ...) (end_date ...) (universe_size ...) (n_steps ...)
+     (initial_cash 1000000.00) (final_portfolio_value 999937.26)
+     (n_round_trips 32)
+     (metrics
+      ((metric_types.metric_type.t.totalpnl -64597.51)
+       (metric_types.metric_type.t.wincount 12)
+       (metric_types.metric_type.t.losscount 20)
+       ...)))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .models import SEVERITY_PNL_MISMATCH, Divergence
+from .sexp_reader import SexpReadError, loads
+from .tolerance import Tolerance
+
+
+@dataclass
+class SimulatorSummary:
+    n_round_trips: int | None = None
+    totalpnl: float | None = None
+    wincount: int | None = None
+    losscount: int | None = None
+    initial_cash: float | None = None
+
+
+_METRIC_PREFIX = "metric_types.metric_type.t."
+
+
+def parse_summary_sexp(path: str | Path) -> SimulatorSummary:
+    p = Path(path)
+    try:
+        text = p.read_text()
+    except OSError as e:
+        raise SummaryParseError(f"{p}: {e}") from e
+    try:
+        tree = loads(text)
+    except SexpReadError as e:
+        raise SummaryParseError(f"{p}: {e}") from e
+
+    if not isinstance(tree, list):
+        raise SummaryParseError(f"{p}: top-level must be an s-expression list")
+
+    fields = _alist_to_dict(tree)
+    out = SimulatorSummary()
+
+    if "n_round_trips" in fields:
+        out.n_round_trips = _to_int(fields["n_round_trips"], path=p, key="n_round_trips")
+    if "initial_cash" in fields:
+        out.initial_cash = _to_float(fields["initial_cash"], path=p, key="initial_cash")
+
+    if "metrics" in fields and isinstance(fields["metrics"], list):
+        metrics = _alist_to_dict(fields["metrics"])
+        for k, v in metrics.items():
+            if not k.startswith(_METRIC_PREFIX):
+                continue
+            short = k[len(_METRIC_PREFIX):]
+            if short == "totalpnl":
+                out.totalpnl = _to_float(v, path=p, key=k)
+            elif short == "wincount":
+                out.wincount = _to_int_via_float(v, path=p, key=k)
+            elif short == "losscount":
+                out.losscount = _to_int_via_float(v, path=p, key=k)
+
+    return out
+
+
+class SummaryParseError(Exception):
+    pass
+
+
+def _alist_to_dict(items: list) -> dict[str, object]:
+    out: dict[str, object] = {}
+    for entry in items:
+        if not isinstance(entry, list) or len(entry) < 1 or not isinstance(entry[0], str):
+            continue
+        key = entry[0]
+        if len(entry) == 1:
+            out[key] = None
+        elif len(entry) == 2:
+            out[key] = entry[1]
+        else:
+            out[key] = entry[1:]
+    return out
+
+
+def _to_float(v: object, *, path: Path, key: str) -> float:
+    if not isinstance(v, str):
+        raise SummaryParseError(f"{path}: {key} expected scalar, got {v!r}")
+    try:
+        return float(v)
+    except ValueError as e:
+        raise SummaryParseError(f"{path}: {key} not a float: {v!r}") from e
+
+
+def _to_int(v: object, *, path: Path, key: str) -> int:
+    if not isinstance(v, str):
+        raise SummaryParseError(f"{path}: {key} expected scalar, got {v!r}")
+    try:
+        return int(v)
+    except ValueError as e:
+        raise SummaryParseError(f"{path}: {key} not an int: {v!r}") from e
+
+
+def _to_int_via_float(v: object, *, path: Path, key: str) -> int:
+    """OCaml emits some integer-valued metrics as floats (e.g. `12` or `12.0`)."""
+    if not isinstance(v, str):
+        raise SummaryParseError(f"{path}: {key} expected scalar, got {v!r}")
+    try:
+        f = float(v)
+    except ValueError as e:
+        raise SummaryParseError(f"{path}: {key} not numeric: {v!r}") from e
+    if f != int(f):
+        raise SummaryParseError(f"{path}: {key} expected integer-valued, got {v!r}")
+    return int(f)
+
+
+def cross_check(
+    sim: SimulatorSummary,
+    *,
+    realized_pnl_total: float,
+    win_count: int,
+    loss_count: int,
+    trade_count: int,
+    tolerance: Tolerance,
+) -> list[Divergence]:
+    divergences: list[Divergence] = []
+
+    if sim.totalpnl is not None and not tolerance.matches(sim.totalpnl, realized_pnl_total):
+        divergences.append(
+            Divergence(
+                type="summary_mismatch",
+                severity=SEVERITY_PNL_MISMATCH,
+                payload={
+                    "field": "realized_pnl_total",
+                    "simulator_field": "metrics.totalpnl",
+                    "simulator_value": sim.totalpnl,
+                    "computed_value": realized_pnl_total,
+                    "diff": realized_pnl_total - sim.totalpnl,
+                },
+            )
+        )
+
+    if sim.wincount is not None and sim.wincount != win_count:
+        divergences.append(
+            Divergence(
+                type="summary_mismatch",
+                severity=SEVERITY_PNL_MISMATCH,
+                payload={
+                    "field": "win_count",
+                    "simulator_field": "metrics.wincount",
+                    "simulator_value": sim.wincount,
+                    "computed_value": win_count,
+                    "diff": win_count - sim.wincount,
+                },
+            )
+        )
+
+    if sim.losscount is not None and sim.losscount != loss_count:
+        divergences.append(
+            Divergence(
+                type="summary_mismatch",
+                severity=SEVERITY_PNL_MISMATCH,
+                payload={
+                    "field": "loss_count",
+                    "simulator_field": "metrics.losscount",
+                    "simulator_value": sim.losscount,
+                    "computed_value": loss_count,
+                    "diff": loss_count - sim.losscount,
+                },
+            )
+        )
+
+    if sim.n_round_trips is not None and sim.n_round_trips != trade_count:
+        divergences.append(
+            Divergence(
+                type="summary_mismatch",
+                severity=SEVERITY_PNL_MISMATCH,
+                payload={
+                    "field": "trade_count",
+                    "simulator_field": "n_round_trips",
+                    "simulator_value": sim.n_round_trips,
+                    "computed_value": trade_count,
+                    "diff": trade_count - sim.n_round_trips,
+                },
+            )
+        )
+
+    return divergences

--- a/tests/fixtures/simple_long.summary_count_diverges.sexp
+++ b/tests/fixtures/simple_long.summary_count_diverges.sexp
@@ -1,0 +1,8 @@
+;; wincount + losscount + n_round_trips deliberately off vs trades.csv.
+((start_date 2024-01-02) (end_date 2024-04-20) (universe_size 3)
+ (n_steps 80) (initial_cash 1000000.00) (final_portfolio_value 1001600.00)
+ (n_round_trips 5)
+ (metrics
+  ((metric_types.metric_type.t.totalpnl 1600.00)
+   (metric_types.metric_type.t.wincount 4)
+   (metric_types.metric_type.t.losscount 1))))

--- a/tests/fixtures/simple_long.summary_match.sexp
+++ b/tests/fixtures/simple_long.summary_match.sexp
@@ -1,0 +1,8 @@
+((start_date 2024-01-02) (end_date 2024-04-20) (universe_size 3)
+ (n_steps 80) (initial_cash 1000000.00) (final_portfolio_value 1001600.00)
+ (n_round_trips 3)
+ (metrics
+  ((metric_types.metric_type.t.totalpnl 1600.00)
+   (metric_types.metric_type.t.wincount 3)
+   (metric_types.metric_type.t.losscount 0)
+   (metric_types.metric_type.t.winrate 100.00))))

--- a/tests/fixtures/simple_long.summary_pnl_diverges.sexp
+++ b/tests/fixtures/simple_long.summary_pnl_diverges.sexp
@@ -1,0 +1,8 @@
+;; totalpnl deliberately off by $100 vs trades.csv sum (panel-golden-class bug).
+((start_date 2024-01-02) (end_date 2024-04-20) (universe_size 3)
+ (n_steps 80) (initial_cash 1000000.00) (final_portfolio_value 1001500.00)
+ (n_round_trips 3)
+ (metrics
+  ((metric_types.metric_type.t.totalpnl 1500.00)
+   (metric_types.metric_type.t.wincount 3)
+   (metric_types.metric_type.t.losscount 0))))

--- a/tests/test_summary_check.py
+++ b/tests/test_summary_check.py
@@ -1,0 +1,212 @@
+"""Tests for the simulator-summary cross-check (Phase 1.5).
+
+Closes the panel-golden-class gap: simulator may emit per-row P&L
+that recomputes correctly while reporting an aggregate `totalpnl` /
+`wincount` / `losscount` / `n_round_trips` that disagrees with the
+sum/count over the trades themselves.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reconciler.cli import EXIT_OK, EXIT_PARSE, EXIT_PNL_MISMATCH, main
+from reconciler.summary_check import (
+    SimulatorSummary,
+    SummaryParseError,
+    cross_check,
+    parse_summary_sexp,
+)
+from reconciler.tolerance import Tolerance
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parse_summary_extracts_known_fields():
+    s = parse_summary_sexp(FIXTURES / "simple_long.summary_match.sexp")
+    assert s.n_round_trips == 3
+    assert s.totalpnl == 1600.00
+    assert s.wincount == 3
+    assert s.losscount == 0
+    assert s.initial_cash == 1000000.0
+
+
+def test_parse_summary_real_panel_golden_format(tmp_path: Path):
+    # Mirrors the actual trading-1 backtest_runner output that surfaced
+    # the bug. wincount/losscount as floats (`3.00`).
+    sexp = """
+((start_date 2019-05-01) (end_date 2020-01-03) (universe_size 7)
+ (n_steps 171) (initial_cash 1000000.00) (final_portfolio_value 1022887.87)
+ (n_round_trips 7)
+ (metrics
+  ((metric_types.metric_type.t.totalpnl -10034.63)
+   (metric_types.metric_type.t.avgholdingdays 18)
+   (metric_types.metric_type.t.wincount 3)
+   (metric_types.metric_type.t.losscount 6)
+   (metric_types.metric_type.t.winrate 33.33))))
+"""
+    p = tmp_path / "summary.sexp"
+    p.write_text(sexp)
+    s = parse_summary_sexp(p)
+    assert s.n_round_trips == 7
+    assert s.totalpnl == -10034.63
+    assert s.wincount == 3
+    assert s.losscount == 6
+
+
+def test_parse_summary_unknown_keys_ignored(tmp_path: Path):
+    sexp = "((n_round_trips 2) (some_future_field 42) (metrics ()))"
+    p = tmp_path / "s.sexp"
+    p.write_text(sexp)
+    s = parse_summary_sexp(p)
+    assert s.n_round_trips == 2
+
+
+def test_parse_summary_malformed_raises(tmp_path: Path):
+    p = tmp_path / "bad.sexp"
+    p.write_text("((unterminated")
+    with pytest.raises(SummaryParseError):
+        parse_summary_sexp(p)
+
+
+def test_cross_check_match_returns_no_divergences():
+    sim = SimulatorSummary(n_round_trips=3, totalpnl=1600.0, wincount=3, losscount=0)
+    out = cross_check(
+        sim,
+        realized_pnl_total=1600.0,
+        win_count=3,
+        loss_count=0,
+        trade_count=3,
+        tolerance=Tolerance.default(),
+    )
+    assert out == []
+
+
+def test_cross_check_pnl_diverges_emits_one():
+    sim = SimulatorSummary(n_round_trips=3, totalpnl=1500.0, wincount=3, losscount=0)
+    out = cross_check(
+        sim,
+        realized_pnl_total=1600.0,
+        win_count=3,
+        loss_count=0,
+        trade_count=3,
+        tolerance=Tolerance.default(),
+    )
+    assert len(out) == 1
+    d = out[0]
+    assert d.type == "summary_mismatch"
+    assert d.severity == 3
+    assert d.payload["field"] == "realized_pnl_total"
+    assert d.payload["simulator_value"] == 1500.0
+    assert d.payload["computed_value"] == 1600.0
+    assert d.payload["diff"] == 100.0
+
+
+def test_cross_check_count_mismatch_emits_per_field():
+    sim = SimulatorSummary(n_round_trips=5, totalpnl=1600.0, wincount=4, losscount=1)
+    out = cross_check(
+        sim,
+        realized_pnl_total=1600.0,
+        win_count=3,
+        loss_count=0,
+        trade_count=3,
+        tolerance=Tolerance.default(),
+    )
+    fields = {d.payload["field"] for d in out}
+    assert fields == {"win_count", "loss_count", "trade_count"}
+    assert all(d.severity == 3 for d in out)
+
+
+def test_cross_check_missing_simulator_field_skipped():
+    # Forward-compat: a summary missing one metric key shouldn't error,
+    # just skip that comparison.
+    sim = SimulatorSummary(n_round_trips=3, totalpnl=None, wincount=3, losscount=0)
+    out = cross_check(
+        sim,
+        realized_pnl_total=99999.0,
+        win_count=3,
+        loss_count=0,
+        trade_count=3,
+        tolerance=Tolerance.default(),
+    )
+    assert out == []
+
+
+def test_cross_check_uses_hybrid_tolerance_for_pnl():
+    # Diff 1e-9 should pass under default rel=1e-6; diff 1.0 should fail.
+    sim_close = SimulatorSummary(totalpnl=1600.0)
+    assert cross_check(
+        sim_close,
+        realized_pnl_total=1600.0 + 1e-9,
+        win_count=0,
+        loss_count=0,
+        trade_count=0,
+        tolerance=Tolerance.default(),
+    ) == []
+    sim_far = SimulatorSummary(totalpnl=1600.0)
+    assert len(cross_check(
+        sim_far,
+        realized_pnl_total=1601.0,
+        win_count=0,
+        loss_count=0,
+        trade_count=0,
+        tolerance=Tolerance.default(),
+    )) == 1
+
+
+def test_cli_summary_match_exits_0(capsys):
+    code = main([
+        "--trades", str(FIXTURES / "simple_long.csv"),
+        "--initial-cash", "1000000",
+        "--summary", str(FIXTURES / "simple_long.summary_match.sexp"),
+    ])
+    assert code == EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["divergences"] == []
+
+
+def test_cli_summary_pnl_diverges_exits_3(capsys):
+    code = main([
+        "--trades", str(FIXTURES / "simple_long.csv"),
+        "--initial-cash", "1000000",
+        "--summary", str(FIXTURES / "simple_long.summary_pnl_diverges.sexp"),
+    ])
+    assert code == EXIT_PNL_MISMATCH
+    out = json.loads(capsys.readouterr().out)
+    summary_div = [d for d in out["divergences"] if d["type"] == "summary_mismatch"]
+    assert len(summary_div) == 1
+    assert summary_div[0]["field"] == "realized_pnl_total"
+    assert summary_div[0]["simulator_value"] == 1500.0
+
+
+def test_cli_summary_counts_diverge_exits_3(capsys):
+    code = main([
+        "--trades", str(FIXTURES / "simple_long.csv"),
+        "--initial-cash", "1000000",
+        "--summary", str(FIXTURES / "simple_long.summary_count_diverges.sexp"),
+    ])
+    assert code == EXIT_PNL_MISMATCH
+    out = json.loads(capsys.readouterr().out)
+    fields = {d["field"] for d in out["divergences"] if d["type"] == "summary_mismatch"}
+    assert fields == {"win_count", "loss_count", "trade_count"}
+
+
+def test_cli_summary_malformed_exits_2(tmp_path, capsys):
+    bad = tmp_path / "bad.sexp"
+    bad.write_text("((((")
+    code = main([
+        "--trades", str(FIXTURES / "simple_long.csv"),
+        "--initial-cash", "1000000",
+        "--summary", str(bad),
+    ])
+    assert code == EXIT_PARSE
+
+
+def test_cli_summary_missing_path_exits_2(tmp_path, capsys):
+    code = main([
+        "--trades", str(FIXTURES / "simple_long.csv"),
+        "--initial-cash", "1000000",
+        "--summary", str(tmp_path / "does_not_exist.sexp"),
+    ])
+    assert code == EXIT_PARSE


### PR DESCRIPTION
## Summary

- New `--summary <path>` CLI flag that parses the simulator's `summary.sexp` and cross-checks reconciler-computed `realized_pnl_total` / `win_count` / `loss_count` / `trade_count` against simulator-reported `metrics.totalpnl` / `wincount` / `losscount` / `n_round_trips`.
- New divergence type `summary_mismatch` at severity 3 (exit 3). Hybrid tolerance for P&L, exact int compare for counts. Missing keys silently skipped (forward-compat).
- Minimal sexp reader (`sexp_reader.py`): atoms, lists, line comments, quoted strings.

## Why

Closes the panel-golden-class gap. Surfaced on `goldens-broad/panel-golden-2019-full` against today's run: every per-row P&L recomputed exactly, but simulator's aggregate `totalpnl` disagreed with sum-of-trades by **$1,659.84**, and `wincount`/`losscount` were each off by 1. Phase 1 reconciler exited 0 because it only verified per-row arithmetic. Phase 1.5 catches these as exit 3.

End-to-end verified against `dev/backtest/scenarios-2026-04-30-…` outputs:

| scenario | per-row | summary x-check | exit |
|---|---|---|---|
| sp500-2019-2023 | 32/32 MATCH | all aggregates agree | 0 |
| panel-golden-2019-full | 7/7 MATCH | totalpnl/wincount/losscount diverge | **3** |

## Test plan

- [x] `pytest -q` → 100 passed, 1 xfailed (pre-existing); +14 new tests covering parse, cross-check unit logic, CLI integration, malformed sexp, missing path, forward-compat (unknown / missing keys).
- [x] Manual smoke against real `summary.sexp` files from both fresh trading-1 runs above.
- [ ] Reviewer eyeballs sexp reader for edge cases (escaped quotes inside quoted atoms, comments inside lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)